### PR TITLE
Improve code.google.com presenter to fetch changes when needed.

### DIFF
--- a/presenter/codegoogle.go
+++ b/presenter/codegoogle.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/shurcooL/go-goon"
 	"github.com/shurcooL/go/gists/gist7480523"
 	"github.com/sourcegraph/go-vcs/vcs"
 	"github.com/sourcegraph/vcsstore/vcsclient"
@@ -109,40 +108,24 @@ func newCodeGoogleComparison(repo *gist7480523.GoPackageRepo) (c codeGoogleCompa
 		return
 	}
 
-	var debug = false
 	commitId, err := r.ResolveRevision(repo.GoPackages()[0].Dir.Repo.VcsRemote.RemoteRev)
 	if err != nil {
 		err1 := r.(vcsclient.RepositoryCloneUpdater).CloneOrUpdate(vcs.RemoteOpts{})
-		fmt.Println("newCodeGoogleComparison: CloneOrUpdate:", err1)
 		if err1 != nil {
 			c.err = MultiError{err, err1}
 			return
 		}
-		fmt.Println("newCodeGoogleComparison: DID NOT work on first try!!!")
-		goon.DumpExpr(repo.GoPackages()[0].Dir.Repo.VcsRemote.RemoteRev)
-		goon.DumpExpr(commitId)
-		goon.DumpExpr(err.Error())
-		goon.DumpExpr(err)
-		debug = true
 		commitId, err1 = r.ResolveRevision(repo.GoPackages()[0].Dir.Repo.VcsRemote.RemoteRev)
 		if err1 != nil {
 			c.err = MultiError{err, err1}
 			return
 		}
-		fmt.Println("newCodeGoogleComparison: did work on second try!!!!!!!!")
-		goon.DumpExpr(repo.GoPackages()[0].Dir.Repo.VcsRemote.RemoteRev)
-		goon.DumpExpr(commitId)
-	} else {
-		fmt.Println("newCodeGoogleComparison: worked on first try")
 	}
 
 	c.commits, _, c.err = r.Commits(vcs.CommitsOptions{
 		Head: commitId,
 		N:    20, // Cap for now. TODO: Support arbtirary second revision to go until.
 	})
-	if debug {
-		goon.DumpExpr(c)
-	}
 	return
 }
 


### PR DESCRIPTION
We're using a remote vcsstore to fetch changes for `code.google.com/p/...` repos. Sometimes that vcsstore is not yet aware of an update, and previously Go Package Store would be unable to present a detailed list of changes.

This change allows it to try a second time after a `CloneOrUpdate()` call, which should fetch the updates and allow the list of changes to be presented.

@sqs, if you could quickly eyeball this and give it an ok, that'd be great. I've benchmarked it and doing the POST (aka `CloneOrUpdate`) is pretty expensive and takes 800~ ms every time. That's why I opt  to do it only when the first query of the latest commit fails.
