### PR TITLE
Display and link to comments for commits.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ go:
   - 1.4
 install:
   - go get golang.org/x/tools/cmd/vet
-  - go get -t -v ./...
 script:
+  - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d ./)
   - go tool vet ./
   - go test -v -race ./...

--- a/assets/repo.html.tmpl
+++ b/assets/repo.html.tmpl
@@ -34,7 +34,7 @@
 		<div>
 			{{if .Changes}}
 				<ul class="changes-list">
-					{{range .Changes}}<li>{{.Message}}<span class="highlight-on-hover smaller"> <a href="{{.Url}}" target="_blank">Commit</a></span></li>
+					{{range .Changes}}<li>{{.Message}}<span class="highlight-on-hover smaller">{{template "comments" .Comments}} <a href="{{.Url}}" target="_blank">Commit</a></span></li>
 					{{end}}
 				</ul>
 			{{else}}
@@ -46,3 +46,9 @@
 		<div style="clear: both;"></div>
 	</div>
 </div>
+
+{{define "comments"}}
+	{{if .Count}}
+		<a href="{{.Url}}" target="_blank"><span class="octicon octicon-comment smaller">{{.Count}}</span></a>
+	{{end}}
+{{end}}

--- a/assets/style.css
+++ b/assets/style.css
@@ -9,11 +9,11 @@ div.content {
 	margin-top: 20px;
 	margin-bottom: 80px;
 }
-a {
+a, a span {
 	color: #4183c4;
 	text-decoration: none;
 }
-a:hover {
+a:hover, a span:hover {
 	text-decoration: underline;
 }
 h2 {

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func CommonHat(w http.ResponseWriter) {
 		<title>Go Package Store</title>
 		<link href="assets/style.css" rel="stylesheet" type="text/css" />
 		<script src="assets/script.js" type="text/javascript"></script>
+		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/octicons/2.1.2/octicons.css">
 	</head>
 	<body>
 		<div style="width: 100%; text-align: center; background-color: hsl(209, 51%, 92%);">

--- a/presenter/codegoogle.go
+++ b/presenter/codegoogle.go
@@ -48,13 +48,13 @@ func (this codeGooglePresenter) Changes() <-chan Change {
 				foundLocalRev = true
 				break
 			}
-			out <- change{
-				message: firstParagraph(commit.Message),
-				url:     codeGoogleCommitUrl(this.comparison, commit.ID),
+			out <- Change{
+				Message: firstParagraph(commit.Message),
+				Url:     codeGoogleCommitUrl(this.comparison, commit.ID),
 			}
 		}
 		if !foundLocalRev {
-			out <- change{message: "... (there may be more changes, not shown)"}
+			out <- Change{Message: "... (there may be more changes, not shown)"}
 		}
 		close(out)
 	}()

--- a/presenter/generic.go
+++ b/presenter/generic.go
@@ -21,22 +21,3 @@ func (_ genericPresenter) Image() template.URL {
 	return "https://github.com/images/gravatars/gravatar-user-420.png"
 }
 func (_ genericPresenter) Changes() <-chan Change { return nil }
-
-// change is a simple implementation of Change.
-type change struct {
-	message  string
-	url      template.URL
-	comments Comments
-}
-
-func (c change) Message() string {
-	return c.message
-}
-
-func (c change) Url() template.URL {
-	return c.url
-}
-
-func (c change) Comments() Comments {
-	return c.comments
-}

--- a/presenter/generic.go
+++ b/presenter/generic.go
@@ -24,8 +24,9 @@ func (_ genericPresenter) Changes() <-chan Change { return nil }
 
 // change is a simple implementation of Change.
 type change struct {
-	message string
-	url     template.URL
+	message  string
+	url      template.URL
+	comments Comments
 }
 
 func (c change) Message() string {
@@ -34,4 +35,8 @@ func (c change) Message() string {
 
 func (c change) Url() template.URL {
 	return c.url
+}
+
+func (c change) Comments() Comments {
+	return c.comments
 }

--- a/presenter/github.go
+++ b/presenter/github.go
@@ -57,10 +57,17 @@ func (this gitHubPresenter) Changes() <-chan Change {
 	out := make(chan Change)
 	go func() {
 		for index := range this.comparison.cc.Commits {
-			out <- change{
+			change := change{
 				message: firstParagraph(*this.comparison.cc.Commits[len(this.comparison.cc.Commits)-1-index].Commit.Message),
 				url:     template.URL(*this.comparison.cc.Commits[len(this.comparison.cc.Commits)-1-index].HTMLURL),
 			}
+			if commentCount := this.comparison.cc.Commits[len(this.comparison.cc.Commits)-1-index].Commit.CommentCount; commentCount != nil && *commentCount > 0 {
+				change.comments = Comments{
+					Count: *commentCount,
+					Url:   template.URL(*this.comparison.cc.Commits[len(this.comparison.cc.Commits)-1-index].HTMLURL + "#comments"),
+				}
+			}
+			out <- change
 		}
 		close(out)
 	}()

--- a/presenter/github.go
+++ b/presenter/github.go
@@ -57,15 +57,13 @@ func (this gitHubPresenter) Changes() <-chan Change {
 	out := make(chan Change)
 	go func() {
 		for index := range this.comparison.cc.Commits {
-			change := change{
-				message: firstParagraph(*this.comparison.cc.Commits[len(this.comparison.cc.Commits)-1-index].Commit.Message),
-				url:     template.URL(*this.comparison.cc.Commits[len(this.comparison.cc.Commits)-1-index].HTMLURL),
+			change := Change{
+				Message: firstParagraph(*this.comparison.cc.Commits[len(this.comparison.cc.Commits)-1-index].Commit.Message),
+				Url:     template.URL(*this.comparison.cc.Commits[len(this.comparison.cc.Commits)-1-index].HTMLURL),
 			}
 			if commentCount := this.comparison.cc.Commits[len(this.comparison.cc.Commits)-1-index].Commit.CommentCount; commentCount != nil && *commentCount > 0 {
-				change.comments = Comments{
-					Count: *commentCount,
-					Url:   template.URL(*this.comparison.cc.Commits[len(this.comparison.cc.Commits)-1-index].HTMLURL + "#comments"),
-				}
+				change.Comments.Count = *commentCount
+				change.Comments.Url = template.URL(*this.comparison.cc.Commits[len(this.comparison.cc.Commits)-1-index].HTMLURL + "#comments")
 			}
 			out <- change
 		}

--- a/presenter/presenter.go
+++ b/presenter/presenter.go
@@ -17,10 +17,10 @@ type Presenter interface {
 }
 
 // Change represents a single commit message.
-type Change interface {
-	Message() string
-	Url() template.URL
-	Comments() Comments
+type Change struct {
+	Message  string
+	Url      template.URL
+	Comments Comments
 }
 
 type Comments struct {

--- a/presenter/presenter.go
+++ b/presenter/presenter.go
@@ -20,6 +20,12 @@ type Presenter interface {
 type Change interface {
 	Message() string
 	Url() template.URL
+	Comments() Comments
+}
+
+type Comments struct {
+	Count int
+	Url   template.URL
 }
 
 // TODO: Change signature to return (Presenter, error). Some Presenters may or may not match, so we can fall back to another.


### PR DESCRIPTION
Closes #29.

![image](https://cloud.githubusercontent.com/assets/1924134/5697706/53b3ddde-99ad-11e4-8565-79ae278ceb61.png)

- Add Comments to Change.
- Implement Comments fetching for GitHub presenter.
- Use octicons.
- Travis: Move `go get` from install to script step.

Blocking on google/go-github#161.