### PR TITLE
presenter/azul3d: upgrade to semver.v2

### DIFF
--- a/presenter/azul3dorg.go
+++ b/presenter/azul3dorg.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"strings"
 
-	"azul3d.org/semver.v1"
+	"azul3d.org/semver.v2"
 )
 
 var azul3dOrgMatcher = semver.GitHub("azul3d")

--- a/presenter/presenter.go
+++ b/presenter/presenter.go
@@ -52,7 +52,7 @@ func init() {
 		case strings.HasPrefix(goPackage.Bpkg.ImportPath, "github.com/"):
 			importPathElements := strings.Split(goPackage.Bpkg.ImportPath, "/")
 			return newGitHubPresenter(repo, importPathElements[1], importPathElements[2])
-		// azul3d.org package (an instance of semver-based domain, see https://godoc.org/azul3d.org/semver.v1).
+		// azul3d.org package (an instance of semver-based domain, see https://azul3d.org/semver).
 		// Once there are other semver based Go packages, consider adding more generalized support.
 		case strings.HasPrefix(goPackage.Bpkg.ImportPath, "azul3d.org/"):
 			gitHubOwner, gitHubRepo, err := azul3dOrgImportPathToGitHub(goPackage.Bpkg.ImportPath)


### PR DESCRIPTION
This allows "vN-unstable" import paths, as opposed to the old "vN-dev" ones.

I tested this change extensively and saw no issues.