### PR TITLE
Update for go-github API change.

### DIFF
--- a/presentation.go
+++ b/presentation.go
@@ -1,5 +1,7 @@
 package gps
 
+import "context"
+
 // Presentation provides infomation about a Go package repo with an available update.
 type Presentation struct {
 	HomeURL  string   // Home URL of the Go package. Optional (empty string means none available).
@@ -22,4 +24,4 @@ type Comments struct {
 }
 
 // Presenter returns a Presentation for r, or nil if it can't.
-type Presenter func(r *Repo) *Presentation
+type Presenter func(ctx context.Context, r *Repo) *Presentation

--- a/presenter/gitiles/gitiles_test.go
+++ b/presenter/gitiles/gitiles_test.go
@@ -1,6 +1,7 @@
 package gitiles
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -22,7 +23,7 @@ func TestFetchLog(t *testing.T) {
 		}),
 	}
 
-	log, err := fetchLog(client, "")
+	log, err := fetchLog(context.Background(), client, "")
 	if err != nil {
 		t.Fatalf("fetchLog: %v", err)
 	}

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -2,6 +2,7 @@
 package workspace
 
 import (
+	"context"
 	"fmt"
 	"go/build"
 	"log"
@@ -635,7 +636,7 @@ func (p *Pipeline) presentWorker(wg *sync.WaitGroup) {
 // but falls back to a generic presentation if there's nothing better.
 func (p *Pipeline) present(repo *gps.Repo) *gps.Presentation {
 	for _, presenter := range p.presenters {
-		if presentation := presenter(repo); presentation != nil {
+		if presentation := presenter(context.Background(), repo); presentation != nil {
 			return presentation
 		}
 	}


### PR DESCRIPTION
Propagate context to `gps.Presenter` func.

Update for context support added in google/go-github#529.