### PR TITLE
workspace: Check local branch matches default branch first.

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -32,14 +32,14 @@ type Repo struct {
 		// RemoteURL is the remote URL, including scheme.
 		RemoteURL string
 
-		Revision string
+		Revision string // Revision of the default branch (not neccessarily the checked out one).
 	}
 	Remote struct {
 		// RepoURL is the repository URL, including scheme, as determined dynamically from the import path.
 		RepoURL string
 
 		Branch   string // Default branch, as determined from remote.
-		Revision string
+		Revision string // Revision of the default branch.
 	}
 
 	// TODO: Right now, all presenters use Remote.RepoURL as the canonical remote URL, so it must be


### PR DESCRIPTION
We want to check if local branch doesn't match default (as determined
from remote) branch before we check if local revision is empty. This
way, we can report a better error message in a case where the default
branch doesn't exist locally.

Add a sanity check to ensure Remote.Branch is not empty. It's not
expected to be. For consistency with Remote.Revision being empty check.

Fixes #74.

### Before

```
$ Go-Package-Store 
Using all Go packages in GOPATH.
Go Package Store server is running at http://localhost:7043/updates.
skipping "gopkg.in/src-d/go-git.v4" because:
	local revision is empty
```

### After

```
$ Go-Package-Store 
Using all Go packages in GOPATH.
Go Package Store server is running at http://localhost:7043/updates.
skipping "gopkg.in/src-d/go-git.v4" because:
	local branch "v4" doesn't match remote branch "master"
```

/cc @mvdan FYI.