### PR TITLE
Add support for visualizing and updating dependencies (within Gopkg.toml constraints) in dep-enabled projects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Usage
 ```
 Usage: Go-Package-Store [flags]
        [newline separated packages] | Go-Package-Store -stdin [flags]
+  -dep string
+    	Read the list of Go packages from the specified Gopkg.lock file.
   -git-subrepo string
     	Look for Go packages vendored using git-subrepo in the specified vendor directory.
   -godeps string
@@ -39,6 +41,9 @@ Examples:
 
   # Show updates for all golang.org/x/... packages.
   go list golang.org/x/... | Go-Package-Store -stdin
+
+  # Show updates for all dependencies listed in Gopkg.lock file.
+  Go-Package-Store -dep=/path/to/repo/Gopkg.lock
 
   # Show updates for all dependencies listed in vendor.json file.
   Go-Package-Store -govendor=/path/to/repo/vendor/vendor.json

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Usage
 Usage: Go-Package-Store [flags]
        [newline separated packages] | Go-Package-Store -stdin [flags]
   -dep string
-    	Read the list of Go packages from the specified Gopkg.lock file.
+    	Determine the list of Go packages from the specified Gopkg.toml file.
   -git-subrepo string
     	Look for Go packages vendored using git-subrepo in the specified vendor directory.
   -godeps string
@@ -42,8 +42,8 @@ Examples:
   # Show updates for all golang.org/x/... packages.
   go list golang.org/x/... | Go-Package-Store -stdin
 
-  # Show updates for all dependencies listed in Gopkg.lock file.
-  Go-Package-Store -dep=/path/to/repo/Gopkg.lock
+  # Show updates for all dependencies within Gopkg.toml constraints.
+  Go-Package-Store -dep=/path/to/repo/Gopkg.toml
 
   # Show updates for all dependencies listed in vendor.json file.
   Go-Package-Store -govendor=/path/to/repo/vendor/vendor.json

--- a/cmd/Go-Package-Store/dep.go
+++ b/cmd/Go-Package-Store/dep.go
@@ -1,21 +1,53 @@
 package main
 
 import (
-	"github.com/BurntSushi/toml"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 )
 
-type depLock struct {
-	Projects []depLockedProject `toml:"projects"`
+// depDir ensures that "Gopkg.toml" file exists at path,
+// and returns the directory that contains it.
+func depDir(path string) (string, error) {
+	// Check that "Gopkg.toml" file exists.
+	if fi, err := os.Stat(path); err != nil {
+		return "", err
+	} else if !(fi.Name() == "Gopkg.toml" && !fi.IsDir()) {
+		return "", fmt.Errorf("%v is not a Gopkg.toml file", path)
+	}
+	dir := filepath.Dir(path) // Directory containing the Gopkg.toml file.
+	return dir, nil
 }
 
-type depLockedProject struct {
-	Name     string `toml:"name"`
-	Revision string `toml:"revision"`
+// runDepStatus runs dep status in directory dir,
+// returning a parsed list of dependencies and their status.
+func runDepStatus(dir string) (depDependencies, error) {
+	cmd := exec.Command("dep", "status", "-json")
+	cmd.Dir = dir
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	cmd.Stderr = os.Stderr
+	err = cmd.Start()
+	if err != nil {
+		return nil, err
+	}
+	var dependencies depDependencies
+	err = json.NewDecoder(stdout).Decode(&dependencies)
+	if err != nil {
+		return nil, err
+	}
+	err = cmd.Wait()
+	return dependencies, err
 }
 
-// readDepLock reads a Gopkg.lock file at path.
-func readDepLock(path string) (depLock, error) {
-	var l depLock
-	_, err := toml.DecodeFile(path, &l)
-	return l, err
+type depDependencies []depDependency
+
+type depDependency struct {
+	ProjectRoot string // E.g., "github.com/google/go-github".
+	Revision    string // E.g., "6afafa88c26eb51b33a8307c944bd2f0ef227af7".
+	Latest      string // E.g., "fe4b6036cb400908b8903d3df9444b9599a60d57".
 }

--- a/cmd/Go-Package-Store/dep.go
+++ b/cmd/Go-Package-Store/dep.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/BurntSushi/toml"
+)
+
+type depLock struct {
+	Projects []depLockedProject `toml:"projects"`
+}
+
+type depLockedProject struct {
+	Name     string `toml:"name"`
+	Revision string `toml:"revision"`
+}
+
+// readDepLock reads a Gopkg.lock file at path.
+func readDepLock(path string) (depLock, error) {
+	var l depLock
+	_, err := toml.DecodeFile(path, &l)
+	return l, err
+}

--- a/repo.go
+++ b/repo.go
@@ -10,7 +10,8 @@ type Repo struct {
 	// Root is the import path corresponding to the root of the repository.
 	Root string
 
-	// Exactly one of VCS or RemoteVCS should be not nil.
+	// At most one of VCS or RemoteVCS should be not nil.
+	// If both are nil, then Local and Remote structs are expected to be already populated.
 	// TODO: Consider if it'd be better to split this into two distinct structs.
 
 	// VCS allows getting the state of the VCS.
@@ -38,7 +39,7 @@ type Repo struct {
 		// RepoURL is the repository URL, including scheme, as determined dynamically from the import path.
 		RepoURL string
 
-		Branch   string // Default branch, as determined from remote.
+		Branch   string // Default branch, as determined from remote. Only populated if VCS or RemoteVCS is non-nil.
 		Revision string // Revision of the default branch.
 	}
 

--- a/updater/dep.go
+++ b/updater/dep.go
@@ -9,25 +9,19 @@ import (
 	"github.com/shurcooL/Go-Package-Store"
 )
 
-// NewDep returns an Updater that updates Go packages in a project managed by dep.
-// dir controls where the dep binary is executed. If empty string, current working
-// directory is used. If dep binary is not available in PATH, an error will be returned.
-func NewDep(dir string) (gps.Updater, error) {
-	if _, err := exec.LookPath("dep"); err != nil {
-		return nil, fmt.Errorf("dep binary is required for updating, but not available: %v", err)
-	}
-	return dep{dir: dir}, nil
+// Dep is an Updater that updates Go packages in a project managed by dep.
+//
+// It requires the dep binary to be available in PATH.
+type Dep struct {
+	// Dir specifies where the dep binary is executed.
+	// If empty, current working directory is used.
+	Dir string
 }
 
-// dep is an Updater that updates Go packages in a project managed by dep.
-type dep struct {
-	dir string // Directory where to execute dep binary.
-}
-
-func (gu dep) Update(repo *gps.Repo) error {
+func (d Dep) Update(repo *gps.Repo) error {
 	cmd := exec.Command("dep", "ensure", "-update", repo.Root)
 	fmt.Println(strings.Join(cmd.Args, " "))
-	cmd.Dir = gu.dir
+	cmd.Dir = d.Dir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()

--- a/updater/dep.go
+++ b/updater/dep.go
@@ -1,0 +1,35 @@
+package updater
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/shurcooL/Go-Package-Store"
+)
+
+// NewDep returns an Updater that updates Go packages in a project managed by dep.
+// dir controls where the dep binary is executed. If empty string, current working
+// directory is used. If dep binary is not available in PATH, an error will be returned.
+func NewDep(dir string) (gps.Updater, error) {
+	if _, err := exec.LookPath("dep"); err != nil {
+		return nil, fmt.Errorf("dep binary is required for updating, but not available: %v", err)
+	}
+	return dep{dir: dir}, nil
+}
+
+// dep is an Updater that updates Go packages in a project managed by dep.
+type dep struct {
+	dir string // Directory where to execute dep binary.
+}
+
+func (gu dep) Update(repo *gps.Repo) error {
+	cmd := exec.Command("dep", "ensure", "-update", repo.Root)
+	fmt.Println(strings.Join(cmd.Args, " "))
+	cmd.Dir = gu.dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return err
+}


### PR DESCRIPTION
This PR adds support for [`dep`](https://github.com/golang/dep) and resolves #81. /cc @sdboyer @bits01 @bradleyfalzon

A new `-dep` flag is added. Using it requires `dep` binary to be available in PATH. When `-dep` flag is set to point to a `Gopkg.toml` file of a `dep`-enabled project, it runs `dep status` in the containing directory to determine available updates (within `Gopkg.toml` constraints) and then displays them in a visual form.

The Update (and Update All) buttons are functional. Pressing them executes `dep ensure -update {root}` command in same directory, causing the update to be applied.

E.g.:

```
$ Go-Package-Store -dep=/Users/Gopher/go/src/github.com/bradleyfalzon/gopherci/Gopkg.toml
Determining the list of Go packages from Gopkg.toml file: /Users/Gopher/go/src/github.com/bradleyfalzon/gopherci/Gopkg.toml
Go Package Store server is running at http://localhost:7043/updates.

dep ensure -update github.com/google/go-github
Done.
```

![image](https://user-images.githubusercontent.com/1924134/29541344-6d9a6126-86a1-11e7-8c49-3faa7e808c67.png)