### PR TITLE
Port to new Vecty API

### DIFF
--- a/component/header.go
+++ b/component/header.go
@@ -21,9 +21,9 @@ type Header struct {
 // Render renders the component.
 func (*Header) Render() *vecty.HTML {
 	return elem.Div(
-		style.Width("100%"), vecty.Style("text-align", "center"), vecty.Style("background-color", "hsl(209, 51%, 92%)"),
+		vecty.Markup(style.Width("100%"), vecty.Style("text-align", "center"), vecty.Style("background-color", "hsl(209, 51%, 92%)")),
 		elem.Span(
-			vecty.Style("background-color", "hsl(209, 51%, 88%)"), vecty.Style("padding", string(style.Px(15))), vecty.Style("display", "inline-block"),
+			vecty.Markup(vecty.Style("background-color", "hsl(209, 51%, 88%)"), vecty.Style("padding", string(style.Px(15))), vecty.Style("display", "inline-block")),
 			vecty.Text("Updates"),
 		),
 	)
@@ -96,10 +96,10 @@ func (u *updatesHeading) Render() *vecty.HTML {
 		status += "Installing Updates..."
 	}
 	return elem.Heading4(
-		vecty.Style("text-align", "left"),
+		vecty.Markup(vecty.Style("text-align", "left")),
 		vecty.Text(status),
 		elem.Span(
-			vecty.Style("float", "right"),
+			vecty.Markup(vecty.Style("float", "right")),
 			u.updateAllButton(),
 		),
 	)
@@ -108,25 +108,29 @@ func (u *updatesHeading) Render() *vecty.HTML {
 func (u *updatesHeading) updateAllButton() *vecty.HTML {
 	if !u.UpdateSupported {
 		return elem.Span(
-			style.Color("gray"), vecty.Style("cursor", "default"),
-			vecty.Property(atom.Title.String(), "Updating repos is not currently supported for this source of repos."),
+			vecty.Markup(
+				style.Color("gray"), vecty.Style("cursor", "default"),
+				vecty.Property(atom.Title.String(), "Updating repos is not currently supported for this source of repos."),
+			),
 			vecty.Text("Update All"),
 		)
 	}
 	switch {
 	case u.Available > 0:
 		return elem.Anchor(
-			prop.Href("/api/update-all"), // TODO: Should it be a separate endpoint or what?
-			event.Click(func(e *vecty.Event) {
-				// TODO.
-				fmt.Println("UpdateAll()")
-				js.Global.Get("UpdateAll").Invoke() // TODO: Do this via action?
-			}).PreventDefault(),
+			vecty.Markup(
+				prop.Href("/api/update-all"), // TODO: Should it be a separate endpoint or what?
+				event.Click(func(e *vecty.Event) {
+					// TODO.
+					fmt.Println("UpdateAll()")
+					js.Global.Get("UpdateAll").Invoke() // TODO: Do this via action?
+				}).PreventDefault(),
+			),
 			vecty.Text("Update All"),
 		)
 	case u.Available == 0:
 		return elem.Span(
-			style.Color("gray"), vecty.Style("cursor", "default"),
+			vecty.Markup(style.Color("gray"), vecty.Style("cursor", "default")),
 			vecty.Text("Update All"),
 		)
 	default:
@@ -143,7 +147,7 @@ func noUpdates() *vecty.HTML { return heading(elem.Heading2, "No Updates Availab
 
 func heading(heading func(markup ...vecty.MarkupOrComponentOrHTML) *vecty.HTML, text string) *vecty.HTML {
 	return heading(
-		vecty.Style("text-align", "center"),
+		vecty.Markup(vecty.Style("text-align", "center")),
 		vecty.Text(text),
 	)
 }

--- a/component/header.go
+++ b/component/header.go
@@ -36,8 +36,8 @@ type updatesHeader struct {
 	CheckingUpdates bool
 }
 
-func (u updatesHeader) Render() vecty.List {
-	var ns vecty.List
+func (u updatesHeader) Render() []vecty.MarkupOrChild {
+	var ns []vecty.MarkupOrChild
 	// Show "Checking for updates..." while still checking.
 	if u.CheckingUpdates {
 		ns = append(ns, checkingForUpdates())

--- a/component/header.go
+++ b/component/header.go
@@ -145,7 +145,7 @@ func checkingForUpdates() *vecty.HTML { return heading(elem.Heading2, "Checking 
 
 func noUpdates() *vecty.HTML { return heading(elem.Heading2, "No Updates Available") }
 
-func heading(heading func(markup ...vecty.MarkupOrComponentOrHTML) *vecty.HTML, text string) *vecty.HTML {
+func heading(heading func(markup ...vecty.MarkupOrChild) *vecty.HTML, text string) *vecty.HTML {
 	return heading(
 		vecty.Markup(vecty.Style("text-align", "center")),
 		vecty.Text(text),

--- a/component/presentation.go
+++ b/component/presentation.go
@@ -55,7 +55,7 @@ func (p *RepoPresentation) Render() *vecty.HTML {
 				),
 			),
 			elem.Div(
-				p.presentationChangesAndError()...,
+				p.presentationChangesAndError(),
 			),
 			elem.Div(
 				vecty.Markup(vecty.Style("clear", "both")),
@@ -188,7 +188,7 @@ func (p *PresentationChanges) Render() *vecty.HTML {
 				Change: &p.Changes[i],
 			})
 		}
-		return elem.UnorderedList(ns...)
+		return elem.UnorderedList(ns)
 	case 0:
 		return elem.Div(
 			vecty.Markup(prop.Class("changes-list")),

--- a/component/presentation.go
+++ b/component/presentation.go
@@ -54,7 +54,9 @@ func (p *RepoPresentation) Render() *vecty.HTML {
 					vecty.Property(atom.Height.String(), "36"),
 				),
 			),
-			p.presentationChangesAndError(),
+			elem.Div(
+				p.presentationChangesAndError()...,
+			),
 			elem.Div(
 				vecty.Markup(vecty.Style("clear", "both")),
 			),
@@ -121,8 +123,8 @@ func (p *RepoPresentation) updateState() *vecty.HTML {
 	}
 }
 
-func (p *RepoPresentation) presentationChangesAndError() *vecty.HTML {
-	return elem.Div(
+func (p *RepoPresentation) presentationChangesAndError() []vecty.MarkupOrChild {
+	return []vecty.MarkupOrChild{
 		vecty.Markup(vecty.Style("word-break", "break-word")),
 		&PresentationChanges{
 			RepoPresentation: p.RepoPresentation,
@@ -135,7 +137,7 @@ func (p *RepoPresentation) presentationChangesAndError() *vecty.HTML {
 				vecty.Text(p.Error),
 			),
 		),
-	)
+	}
 }
 
 // PresentationChanges is a component containing changes within an update.
@@ -173,7 +175,9 @@ func (p *PresentationChanges) Render() *vecty.HTML {
 	//fmt.Println("PresentationChanges.Render()")
 	switch len(p.Changes) {
 	default:
-		var ns vecty.List
+		ns := []vecty.MarkupOrChild{
+			vecty.Markup(prop.Class("changes-list")),
+		}
 		//for _, c := range p.Changes {
 		//	ns = append(ns, &Change{
 		//		Change: c,
@@ -184,10 +188,7 @@ func (p *PresentationChanges) Render() *vecty.HTML {
 				Change: &p.Changes[i],
 			})
 		}
-		return elem.UnorderedList(
-			vecty.Markup(prop.Class("changes-list")),
-			ns,
-		)
+		return elem.UnorderedList(ns...)
 	case 0:
 		return elem.Div(
 			vecty.Markup(prop.Class("changes-list")),

--- a/component/presentation.go
+++ b/component/presentation.go
@@ -54,9 +54,7 @@ func (p *RepoPresentation) Render() *vecty.HTML {
 					vecty.Property(atom.Height.String(), "36"),
 				),
 			),
-			elem.Div(
-				p.presentationChangesAndError(),
-			),
+			p.presentationChangesAndError(),
 			elem.Div(
 				vecty.Markup(vecty.Style("clear", "both")),
 			),
@@ -123,8 +121,8 @@ func (p *RepoPresentation) updateState() *vecty.HTML {
 	}
 }
 
-func (p *RepoPresentation) presentationChangesAndError() vecty.List {
-	return vecty.List{
+func (p *RepoPresentation) presentationChangesAndError() *vecty.HTML {
+	return elem.Div(
 		vecty.Markup(vecty.Style("word-break", "break-word")),
 		&PresentationChanges{
 			RepoPresentation: p.RepoPresentation,
@@ -137,7 +135,7 @@ func (p *RepoPresentation) presentationChangesAndError() vecty.List {
 				vecty.Text(p.Error),
 			),
 		),
-	}
+	)
 }
 
 // PresentationChanges is a component containing changes within an update.
@@ -175,9 +173,7 @@ func (p *PresentationChanges) Render() *vecty.HTML {
 	//fmt.Println("PresentationChanges.Render()")
 	switch len(p.Changes) {
 	default:
-		ns := vecty.List{
-			vecty.Markup(prop.Class("changes-list")),
-		}
+		var ns vecty.List
 		//for _, c := range p.Changes {
 		//	ns = append(ns, &Change{
 		//		Change: c,
@@ -188,7 +184,10 @@ func (p *PresentationChanges) Render() *vecty.HTML {
 				Change: &p.Changes[i],
 			})
 		}
-		return elem.UnorderedList(ns)
+		return elem.UnorderedList(
+			vecty.Markup(prop.Class("changes-list")),
+			ns,
+		)
 	case 0:
 		return elem.Div(
 			vecty.Markup(prop.Class("changes-list")),

--- a/component/presentation.go
+++ b/component/presentation.go
@@ -28,33 +28,37 @@ type RepoPresentation struct {
 // Render renders the component.
 func (p *RepoPresentation) Render() *vecty.HTML {
 	return elem.Div(
-		prop.Class("list-entry go-package-update"),
-		vecty.Property(atom.Id.String(), p.RepoRoot),
-		vecty.Style("position", "relative"),
+		vecty.Markup(
+			prop.Class("list-entry go-package-update"),
+			vecty.Property(atom.Id.String(), p.RepoRoot),
+			vecty.Style("position", "relative"),
+		),
 		elem.Div(
-			prop.Class("list-entry-header"),
+			vecty.Markup(prop.Class("list-entry-header")),
 			elem.Span(
-				vecty.Property(atom.Title.String(), p.ImportPathPattern),
+				vecty.Markup(vecty.Property(atom.Title.String(), p.ImportPathPattern)),
 				p.importPathPattern(),
 			),
 			elem.Div(
-				vecty.Style("float", "right"),
+				vecty.Markup(vecty.Style("float", "right")),
 				p.updateState(),
 			),
 		),
 		elem.Div(
-			prop.Class("list-entry-body"),
+			vecty.Markup(prop.Class("list-entry-body")),
 			elem.Image(
-				vecty.Style("float", "left"), vecty.Style("border-radius", string(style.Px(4))),
-				vecty.Property(atom.Src.String(), p.ImageURL),
-				vecty.Property(atom.Width.String(), "36"),
-				vecty.Property(atom.Height.String(), "36"),
+				vecty.Markup(
+					vecty.Style("float", "left"), vecty.Style("border-radius", string(style.Px(4))),
+					vecty.Property(atom.Src.String(), p.ImageURL),
+					vecty.Property(atom.Width.String(), "36"),
+					vecty.Property(atom.Height.String(), "36"),
+				),
 			),
 			elem.Div(
 				p.presentationChangesAndError()...,
 			),
 			elem.Div(
-				vecty.Style("clear", "both"),
+				vecty.Markup(vecty.Style("clear", "both")),
 			),
 		),
 	)
@@ -65,9 +69,11 @@ func (p *RepoPresentation) importPathPattern() *vecty.HTML {
 	switch p.HomeURL {
 	default:
 		return elem.Anchor(
-			prop.Href(p.HomeURL),
-			// TODO: Add rel="noopener", see https://dev.to/ben/the-targetblank-vulnerability-by-example.
-			vecty.Property(atom.Target.String(), "_blank"),
+			vecty.Markup(
+				prop.Href(p.HomeURL),
+				// TODO: Add rel="noopener", see https://dev.to/ben/the-targetblank-vulnerability-by-example.
+				vecty.Property(atom.Target.String(), "_blank"),
+			),
 			elem.Strong(vecty.Text(p.ImportPathPattern)),
 		)
 	case "":
@@ -78,31 +84,35 @@ func (p *RepoPresentation) importPathPattern() *vecty.HTML {
 func (p *RepoPresentation) updateState() *vecty.HTML {
 	if !p.UpdateSupported {
 		return elem.Span(
-			style.Color("gray"), vecty.Style("cursor", "default"),
-			vecty.Property(atom.Title.String(), "Updating repos is not currently supported for this source of repos."),
+			vecty.Markup(
+				style.Color("gray"), vecty.Style("cursor", "default"),
+				vecty.Property(atom.Title.String(), "Updating repos is not currently supported for this source of repos."),
+			),
 			vecty.Text("Update"),
 		)
 	}
 	switch p.UpdateState {
 	case model.Available:
 		return elem.Anchor(
-			prop.Href("/api/update"),
-			event.Click(func(e *vecty.Event) {
-				// TODO.
-				fmt.Printf("UpdateRepository(%q)\n", p.RepoRoot)
-				// TODO: Modifying underlying model is bad because Restore can't tell if something changed...
-				p.UpdateState = model.Updating // TODO: Do this via action.
-				started := time.Now()
-				vecty.Rerender(p)
-				fmt.Println("render RepoPresentation:", time.Since(started))
-				js.Global.Get("UpdateRepository").Invoke(p.RepoRoot)
+			vecty.Markup(
+				prop.Href("/api/update"),
+				event.Click(func(e *vecty.Event) {
+					// TODO.
+					fmt.Printf("UpdateRepository(%q)\n", p.RepoRoot)
+					// TODO: Modifying underlying model is bad because Restore can't tell if something changed...
+					p.UpdateState = model.Updating // TODO: Do this via action.
+					started := time.Now()
+					vecty.Rerender(p)
+					fmt.Println("render RepoPresentation:", time.Since(started))
+					js.Global.Get("UpdateRepository").Invoke(p.RepoRoot)
 
-			}).PreventDefault(),
+				}).PreventDefault(),
+			),
 			vecty.Text("Update"),
 		)
 	case model.Updating:
 		return elem.Span(
-			style.Color("gray"), vecty.Style("cursor", "default"),
+			vecty.Markup(style.Color("gray"), vecty.Style("cursor", "default")),
 			vecty.Text("Updating..."),
 		)
 	case model.Updated:
@@ -115,13 +125,13 @@ func (p *RepoPresentation) updateState() *vecty.HTML {
 
 func (p *RepoPresentation) presentationChangesAndError() vecty.List {
 	return vecty.List{
-		vecty.Style("word-break", "break-word"),
+		vecty.Markup(vecty.Style("word-break", "break-word")),
 		&PresentationChanges{
 			RepoPresentation: p.RepoPresentation,
 		},
 		vecty.If(p.Error != "",
 			elem.Paragraph(
-				prop.Class("presentation-error"),
+				vecty.Markup(prop.Class("presentation-error")),
 				elem.Strong(vecty.Text("Error:")),
 				vecty.Text(" "),
 				vecty.Text(p.Error),
@@ -166,7 +176,7 @@ func (p *PresentationChanges) Render() *vecty.HTML {
 	switch len(p.Changes) {
 	default:
 		ns := vecty.List{
-			prop.Class("changes-list"),
+			vecty.Markup(prop.Class("changes-list")),
 		}
 		//for _, c := range p.Changes {
 		//	ns = append(ns, &Change{
@@ -181,7 +191,7 @@ func (p *PresentationChanges) Render() *vecty.HTML {
 		return elem.UnorderedList(ns...)
 	case 0:
 		return elem.Div(
-			prop.Class("changes-list"),
+			vecty.Markup(prop.Class("changes-list")),
 			vecty.Text("unknown changes"),
 			vecty.If(p.LocalRevision != "",
 				vecty.Text(" from "),
@@ -206,18 +216,20 @@ func (c *Change) Render() *vecty.HTML {
 	return elem.ListItem(
 		vecty.Text(c.Message),
 		elem.Span(
-			prop.Class("highlight-on-hover"),
+			vecty.Markup(prop.Class("highlight-on-hover")),
 			elem.Anchor(
-				prop.Href(c.URL),
-				// TODO: Add rel="noopener", see https://dev.to/ben/the-targetblank-vulnerability-by-example.
-				vecty.Property(atom.Target.String(), "_blank"),
-				vecty.Style("color", "gray"),
-				vecty.Property(atom.Title.String(), "Commit"),
-				vecty.UnsafeHTML(octiconGitCommit),
+				vecty.Markup(
+					prop.Href(c.URL),
+					// TODO: Add rel="noopener", see https://dev.to/ben/the-targetblank-vulnerability-by-example.
+					vecty.Property(atom.Target.String(), "_blank"),
+					vecty.Style("color", "gray"),
+					vecty.Property(atom.Title.String(), "Commit"),
+					vecty.UnsafeHTML(octiconGitCommit),
+				),
 			),
 		),
 		elem.Span(
-			vecty.Style("float", "right"), vecty.Style("margin-right", string(style.Px(6))),
+			vecty.Markup(vecty.Style("float", "right"), vecty.Style("margin-right", string(style.Px(6)))),
 			&Comments{Comments: &c.Comments},
 		),
 	)
@@ -237,14 +249,18 @@ func (c *Comments) Render() *vecty.HTML {
 		return nil
 	}
 	return elem.Anchor(
-		prop.Href(c.URL),
-		// TODO: Add rel="noopener", see https://dev.to/ben/the-targetblank-vulnerability-by-example.
-		vecty.Property(atom.Target.String(), "_blank"),
-		vecty.Style("color", "gray"),
-		vecty.Property(atom.Title.String(), fmt.Sprintf("%d comments", c.Count)),
+		vecty.Markup(
+			prop.Href(c.URL),
+			// TODO: Add rel="noopener", see https://dev.to/ben/the-targetblank-vulnerability-by-example.
+			vecty.Property(atom.Target.String(), "_blank"),
+			vecty.Style("color", "gray"),
+			vecty.Property(atom.Title.String(), fmt.Sprintf("%d comments", c.Count)),
+		),
 		elem.Span(
-			style.Color("currentColor"), vecty.Style("margin-right", string(style.Px(4))),
-			vecty.UnsafeHTML(octiconComment),
+			vecty.Markup(
+				style.Color("currentColor"), vecty.Style("margin-right", string(style.Px(4))),
+				vecty.UnsafeHTML(octiconComment),
+			),
 		),
 		vecty.Text(fmt.Sprint(c.Count)),
 	)
@@ -259,9 +275,9 @@ type CommitID struct {
 // Render renders the component.
 func (c *CommitID) Render() *vecty.HTML {
 	return elem.Abbreviation(
-		vecty.Property(atom.Title.String(), c.ID),
+		vecty.Markup(vecty.Property(atom.Title.String(), c.ID)),
 		elem.Code(
-			prop.Class("commitID"),
+			vecty.Markup(prop.Class("commitID")),
 			vecty.Text(c.commitID()),
 		),
 	)

--- a/component/updates.go
+++ b/component/updates.go
@@ -8,18 +8,22 @@ import (
 )
 
 // UpdatesContent returns the entire content of updates tab.
-func UpdatesContent(rps []*model.RepoPresentation, checkingUpdates bool) vecty.List {
-	return vecty.List{
+func UpdatesContent(rps []*model.RepoPresentation, checkingUpdates bool) []vecty.MarkupOrChild {
+	return []vecty.MarkupOrChild{
 		&Header{},
 		elem.Div(
 			vecty.Markup(prop.Class("center-max-width")),
-			updatesContent(rps, checkingUpdates),
+			elem.Div(
+				updatesContent(rps, checkingUpdates)...,
+			),
 		),
 	}
 }
 
-func updatesContent(rps []*model.RepoPresentation, checkingUpdates bool) *vecty.HTML {
-	var content vecty.List
+func updatesContent(rps []*model.RepoPresentation, checkingUpdates bool) []vecty.MarkupOrChild {
+	var content = []vecty.MarkupOrChild{
+		vecty.Markup(prop.Class("content")),
+	}
 
 	content = append(content,
 		updatesHeader{
@@ -40,8 +44,5 @@ func updatesContent(rps []*model.RepoPresentation, checkingUpdates bool) *vecty.
 		})
 	}
 
-	return elem.Div(
-		vecty.Markup(prop.Class("content")),
-		content,
-	)
+	return content
 }

--- a/component/updates.go
+++ b/component/updates.go
@@ -13,15 +13,13 @@ func UpdatesContent(rps []*model.RepoPresentation, checkingUpdates bool) vecty.L
 		&Header{},
 		elem.Div(
 			vecty.Markup(prop.Class("center-max-width")),
-			elem.Div(
-				updatesContent(rps, checkingUpdates),
-			),
+			updatesContent(rps, checkingUpdates),
 		),
 	}
 }
 
-func updatesContent(rps []*model.RepoPresentation, checkingUpdates bool) vecty.List {
-	var content = vecty.List{prop.Class("content")}
+func updatesContent(rps []*model.RepoPresentation, checkingUpdates bool) *vecty.HTML {
+	var content vecty.List
 
 	content = append(content,
 		updatesHeader{
@@ -42,5 +40,8 @@ func updatesContent(rps []*model.RepoPresentation, checkingUpdates bool) vecty.L
 		})
 	}
 
-	return content
+	return elem.Div(
+		vecty.Markup(prop.Class("content")),
+		content,
+	)
 }

--- a/component/updates.go
+++ b/component/updates.go
@@ -12,7 +12,7 @@ func UpdatesContent(rps []*model.RepoPresentation, checkingUpdates bool) vecty.L
 	return vecty.List{
 		&Header{},
 		elem.Div(
-			prop.Class("center-max-width"),
+			vecty.Markup(prop.Class("center-max-width")),
 			elem.Div(
 				updatesContent(rps, checkingUpdates)...,
 			),

--- a/component/updates.go
+++ b/component/updates.go
@@ -14,7 +14,7 @@ func UpdatesContent(rps []*model.RepoPresentation, checkingUpdates bool) vecty.L
 		elem.Div(
 			vecty.Markup(prop.Class("center-max-width")),
 			elem.Div(
-				updatesContent(rps, checkingUpdates)...,
+				updatesContent(rps, checkingUpdates),
 			),
 		),
 	}

--- a/frontend/main.go
+++ b/frontend/main.go
@@ -155,7 +155,7 @@ func (b *UpdatesBody) Render() *vecty.HTML {
 		gpscomponent.UpdatesContent(
 			store.RPs(),
 			store.CheckingUpdates(),
-		),
+		)...,
 	)
 }
 

--- a/frontend/main.go
+++ b/frontend/main.go
@@ -155,7 +155,7 @@ func (b *UpdatesBody) Render() *vecty.HTML {
 		gpscomponent.UpdatesContent(
 			store.RPs(),
 			store.CheckingUpdates(),
-		)...,
+		),
 	)
 }
 


### PR DESCRIPTION
This change ports Go-Package-Store over to the new Vecty API, which recently had a [breaking change](https://github.com/gopherjs/vecty/blob/master/doc/CHANGELOG.md#sept-2-2017-pr-134-major-breaking-change).

Relies on PR https://github.com/gopherjs/vecty/pull/138 being merged first, which fixes a Vecty regression observed here.

No visual / functional changes are made, this just switches over to the new API. I ran out of time while writing this PR to properly make the commits very small / logical and reference exact README links. It's still best reviewed as individual commits, but the last commit in specific is not perfectly split apart into logical pieces. I won't have time to update this PR for probably a few more weeks, so if helpful please feel free to take / modify my changes here as you see fit :) I'll do my best to answer any questions here as I have time.