### PR TITLE
Update components for render efficiency

### DIFF
--- a/component/presentation.go
+++ b/component/presentation.go
@@ -22,7 +22,12 @@ import (
 // TODO: Dedup with workspace.RepoPresentation. Maybe.
 type RepoPresentation struct {
 	vecty.Core
-	*model.RepoPresentation
+	*model.RepoPresentation `vecty:"prop"`
+}
+
+// Key implements vecty.Keyer
+func (p *RepoPresentation) Key() interface{} {
+	return p.RepoRoot
 }
 
 // Render renders the component.
@@ -54,9 +59,7 @@ func (p *RepoPresentation) Render() *vecty.HTML {
 					vecty.Property(atom.Height.String(), "36"),
 				),
 			),
-			elem.Div(
-				p.presentationChangesAndError()...,
-			),
+			p.presentationChangesAndError(),
 			elem.Div(
 				vecty.Markup(vecty.Style("clear", "both")),
 			),
@@ -123,8 +126,8 @@ func (p *RepoPresentation) updateState() *vecty.HTML {
 	}
 }
 
-func (p *RepoPresentation) presentationChangesAndError() []vecty.MarkupOrChild {
-	return []vecty.MarkupOrChild{
+func (p *RepoPresentation) presentationChangesAndError() *vecty.HTML {
+	return elem.Div(
 		vecty.Markup(vecty.Style("word-break", "break-word")),
 		&PresentationChanges{
 			RepoPresentation: p.RepoPresentation,
@@ -137,7 +140,7 @@ func (p *RepoPresentation) presentationChangesAndError() []vecty.MarkupOrChild {
 				vecty.Text(p.Error),
 			),
 		),
-	}
+	)
 }
 
 // PresentationChanges is a component containing changes within an update.
@@ -146,7 +149,7 @@ type PresentationChanges struct {
 	//Changes        []*Change
 	//LocalRevision  string // Only needed if len(Changes) == 0.
 	//RemoteRevision string // Only needed if len(Changes) == 0.
-	*model.RepoPresentation // Only uses Changes, and if len(Changes) == 0, then LocalRevision and RemoteRevision.
+	*model.RepoPresentation `vecty:"prop"` // Only uses Changes, and if len(Changes) == 0, then LocalRevision and RemoteRevision.
 }
 
 // Restore is called when the component should restore itself against a
@@ -175,20 +178,16 @@ func (p *PresentationChanges) Render() *vecty.HTML {
 	//fmt.Println("PresentationChanges.Render()")
 	switch len(p.Changes) {
 	default:
-		ns := []vecty.MarkupOrChild{
-			vecty.Markup(prop.Class("changes-list")),
-		}
-		//for _, c := range p.Changes {
-		//	ns = append(ns, &Change{
-		//		Change: c,
-		//	})
-		//}
+		var changes vecty.List
 		for i := range p.Changes { // TODO: Consider changing model.RepoPresentation.Changes type to []*Change to simplify this.
-			ns = append(ns, &Change{
+			changes = append(changes, &Change{
 				Change: &p.Changes[i],
 			})
 		}
-		return elem.UnorderedList(ns...)
+		return elem.UnorderedList(
+			vecty.Markup(prop.Class("changes-list")),
+			changes,
+		)
 	case 0:
 		return elem.Div(
 			vecty.Markup(prop.Class("changes-list")),
@@ -208,7 +207,12 @@ func (p *PresentationChanges) Render() *vecty.HTML {
 // Change is a component for a single commit message.
 type Change struct {
 	vecty.Core
-	*model.Change
+	*model.Change `vecty:"prop"`
+}
+
+// Key implements vecty.Keyer
+func (c *Change) Key() interface{} {
+	return c.URL
 }
 
 // Render renders the component.
@@ -240,7 +244,7 @@ func (c *Change) Render() *vecty.HTML {
 // TODO: Consider inlining this into Change component, we'll see.
 type Comments struct {
 	vecty.Core
-	*model.Comments
+	*model.Comments `vecty:"prop"`
 }
 
 // Render renders the component.
@@ -269,7 +273,7 @@ func (c *Comments) Render() *vecty.HTML {
 // CommitID is a component that displays a short commit ID, with the full one available in tooltip.
 type CommitID struct {
 	vecty.Core
-	ID string
+	ID string `vecty:"prop"`
 }
 
 // Render renders the component.

--- a/component/updates.go
+++ b/component/updates.go
@@ -8,34 +8,36 @@ import (
 )
 
 // UpdatesContent returns the entire content of updates tab.
-func UpdatesContent(rps []*model.RepoPresentation, checkingUpdates bool) []vecty.MarkupOrChild {
-	return []vecty.MarkupOrChild{
+func UpdatesContent(rps []*model.RepoPresentation, checkingUpdates bool) vecty.List {
+	return vecty.List{
 		&Header{},
 		elem.Div(
 			vecty.Markup(prop.Class("center-max-width")),
 			elem.Div(
-				updatesContent(rps, checkingUpdates)...,
+				vecty.Markup(prop.Class("content")),
+				&updatesHeader{RPs: rps, CheckingUpdates: checkingUpdates},
+				updatesContent(rps),
 			),
 		),
 	}
 }
 
-func updatesContent(rps []*model.RepoPresentation, checkingUpdates bool) []vecty.MarkupOrChild {
-	var content = []vecty.MarkupOrChild{
-		vecty.Markup(prop.Class("content")),
-	}
-
-	content = append(content,
-		updatesHeader{
-			RPs:             rps,
-			CheckingUpdates: checkingUpdates,
-		}.Render()...,
-	)
-
+func updatesContent(rps []*model.RepoPresentation) vecty.List {
+	var content vecty.List
 	wroteInstalledUpdates := false
 	for _, rp := range rps {
 		if rp.UpdateState == model.Updated && !wroteInstalledUpdates {
-			content = append(content, InstalledUpdates())
+			content = append(content,
+				elem.Heading3(
+					vecty.Markup(
+						// This element is mixed with keyed siblings, we choose an
+						// arbitrary key here that can not conflict with any siblings.
+						vecty.Key("__gps_installed_updates"),
+						vecty.Style("text-align", "center"),
+					),
+					vecty.Text("Installed Updates"),
+				),
+			)
 			wroteInstalledUpdates = true
 		}
 

--- a/frontend/main.go
+++ b/frontend/main.go
@@ -155,7 +155,7 @@ func (b *UpdatesBody) Render() *vecty.HTML {
 		gpscomponent.UpdatesContent(
 			store.RPs(),
 			store.CheckingUpdates(),
-		)...,
+		),
 	)
 }
 


### PR DESCRIPTION
As discussed in https://github.com/gopherjs/vecty/issues/149#issuecomment-330736079, this is a quick pass at making GPS render more efficiently.  As we've just landed keyed children, this seemed like an opportune moment to have a look at this.

Let me start with some background details, and I'll leave some line comments, to further explain what I'm aiming for here.

First off, I think it's valuable to read React's [Reconcilliation](https://reactjs.org/docs/reconciliation.html) docs to understand what the renderer has to do on every update, as almost every concept there maps directly to how Vecty operates.  The gist is that if children of an element are unstable, and change type, this results in an expensive operation to tear down the entire tree of each such affected child, and replace it with a new one.  To expand on that - if an element is removed, every sibling below that element will at minimum need to be mutated, and possibly replaced entirely.

React makes it slightly more difficult for you to shoot yourself in the performance foot, as its render values are  (mostly-)logic-free templated blocks of text, so it's more obvious if you're doing something unusual, like rendering a list of elements that may change length between renders, since you need to produce that list outside the normal rendering system.  Vecty's programmatic approach is more flexible, but that flexibility can lead to performance loss if abused.  Vecty does now have tools to help with these scenarios though: `vecty.List`; `vecty.If`; and `vecty.Keyer`.

- `vecty.List` renders its elements into the parent in a separate context, so that the `List` sibling's positions aren't affected by changes in the length of the `List`.
- `vecty.If` allows optional rendering of a child, but keeps track of its position, so that when the child is not rendered, it doesn't affect the position of children below it.
- `vecty.Keyer` is an interface that can be implemented by components (and enabled on `*HTML` using the `vecty.Key()` markup) to uniquely identify children, then they can be _moved_ intact, instead of being torn down and recreated.

Appending to a slice of `[]vecty.MarkupOrChild`, or `[]vecty.ComponentOrHTML` with variable content is a sure-fire way to encounter poor render performance.  So, I've made liberal use of `vecty.List` improve various sections of these components, and implemented `vecty.Keyer`s on the components I think are applicable.  I've also added `prop` tags to component fields where necessary - the justification for these is more involved, but I think it should become more clear once we have a dispatcher implementation (and documentation).

There's obviously no obligation to take these changes as-is, and I've not run them against a production build (since I'm not sure how to do that), but I hope they're at least helpful as an example.  These changes are not exhaustive either, there are probably other improvements that could be made.

I'd certainly appreciate any feedback you have.