### PR TITLE
Move "Recently Installed Updates" section to the top.

### DIFF
--- a/_data/component/main.go
+++ b/_data/component/main.go
@@ -18,13 +18,14 @@ type UpdatesBody struct {
 func (*UpdatesBody) Render() vecty.ComponentOrHTML {
 	return elem.Body(
 		gpscomponent.UpdatesContent(
-			mockComponentRPs,
+			mockActive,
+			mockHistory,
 			true,
 		)...,
 	)
 }
 
-var mockComponentRPs = []*model.RepoPresentation{
+var mockActive = []*model.RepoPresentation{
 	{
 		RepoRoot:          "github.com/gopherjs/gopherjs",
 		ImportPathPattern: "github.com/gopherjs/gopherjs/...",
@@ -95,6 +96,9 @@ var mockComponentRPs = []*model.RepoPresentation{
 		UpdateState:       model.Available,
 		UpdateSupported:   true,
 	},
+}
+
+var mockHistory = []*model.RepoPresentation{
 	{
 		RepoRoot:          "golang.org/x/image",
 		ImportPathPattern: "golang.org/x/image/...",

--- a/frontend/main.go
+++ b/frontend/main.go
@@ -140,7 +140,8 @@ type UpdatesBody struct {
 func (b *UpdatesBody) Render() vecty.ComponentOrHTML {
 	return elem.Body(
 		gpscomponent.UpdatesContent(
-			store.RPs(),
+			store.Active(),
+			store.History(),
 			store.CheckingUpdates(),
 		)...,
 	)


### PR DESCRIPTION
This change implements a minor presentation redesign, where the "Recently Installed Updates" section is moved at the top, above the "Updates Available" section. Previously it was at the bottom.

The motivation to do this is to improve the user experience when installing updates from top to bottom. This way, the recently updated package moves up to the section above, which is a much smaller jump than moving it all the way to the bottom of the page.

Clean up some of the code in the process.

Regenerate `assets`.

Fixes #63. /cc @mvdan